### PR TITLE
Fix Debug task to avoid fragile npm argument forwarding

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -32,11 +32,7 @@
       "command": "npm",
       "args": [
         "run",
-        "start",
-        "--",
-        "desktop",
-        "--app",
-        "excel"
+        "start:desktop"
       ],
       "presentation": {
         "clear": true,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "signin": "office-addin-dev-settings m365-account login",
     "signout": "office-addin-dev-settings m365-account logout",
     "start": "office-addin-debugging start manifest.xml",
+    "start:desktop": "office-addin-debugging start manifest.xml desktop --app excel",
     "stop": "office-addin-debugging stop manifest.xml",
     "test": "npm run test:unit && npm run test:e2e",
     "test:e2e": "mocha -r ts-node/register test/end-to-end/*.ts",


### PR DESCRIPTION
### Problem

The generated `Debug: Excel Desktop` VS Code task runs:

```
npm run start -- desktop --app excel
```

This relies on npm forwarding the `--app` **option flag** across the `--` separator. On some npm versions the flag is not forwarded, so the command resolves to:

```
office-addin-debugging start manifest.xml desktop excel
```

That passes **3 positional arguments** to `start` (which accepts only `<manifest-path> [platform]`), producing:

```
error: too many arguments for 'start'. Expected 2 arguments but got 3.
```

Because the debug task aborts before the dev server starts, Excel then reports *"Add-in ... failed to download a required resource."* This was hit by a customer scaffolding an **Excel Custom Functions + Shared Runtime** project and pressing **F5**.

### Fix

Move the arguments into a dedicated `start:desktop` npm script so nothing is forwarded through `--`:

- `package.json`: add `"start:desktop": "office-addin-debugging start manifest.xml desktop --app excel"`
- `.vscode/tasks.json`: `Debug: Excel Desktop` now runs `["run", "start:desktop"]`

This keeps the `desktop` / `--app excel` intent, is immune to npm's `--` handling, and is backward compatible (identical result on old and new npm). The new script is additive — the existing `start` script and `npm start` flow are unchanged.

Verified locally: F5 builds, starts the dev server, and sideloads the add-in into Excel; custom functions execute.

### Note on scope

The same `npm run start -- <platform> --app <host>` pattern exists in the sibling template repos (`Excel-Custom-Functions`, `Excel-Custom-Functions-JS`, `Excel-Custom-Functions-Shared-JS`, and the `Office-Addin-TaskPane*` / React repos). Starting with this repo since it's the one in the reported issue — happy to mirror the same fix across the others once the approach is confirmed. For the multi-host TaskPane manifests, the `--app` value must be preserved (it selects which host to launch), which this script-based approach supports.